### PR TITLE
provide getPackageManager through system context

### DIFF
--- a/android/sdk/src/main/java/com/viam/sdk/android/module/fake/FakeContext.java
+++ b/android/sdk/src/main/java/com/viam/sdk/android/module/fake/FakeContext.java
@@ -77,8 +77,7 @@ public class FakeContext extends Context {
     }
   }
 
-  public static Context getSystemContext() {
-    // warning: race condition
+  public static synchronized Context getSystemContext() {
     if (systemContext == null) {
       systemContext = createSystemContext();
     }


### PR DESCRIPTION
## What changed
- support getPackageManager in FakeContext
- ContextImpl.getSystemContext internals in FakeContext
## Why
A user of this was crashing on a getPackageManager call
