### PR TITLE
RSDK-7393 - add doCommand to sensor service

### DIFF
--- a/core/sdk/src/main/java/com/viam/sdk/core/component/sensor/SensorRPCService.java
+++ b/core/sdk/src/main/java/com/viam/sdk/core/component/sensor/SensorRPCService.java
@@ -44,6 +44,17 @@ public class SensorRPCService extends SensorServiceGrpc.SensorServiceImplBase
     }
 
     @Override
+    public void doCommand(Common.DoCommandRequest request,
+        StreamObserver<Common.DoCommandResponse> responseObserver) {
+        final com.viam.sdk.core.component.sensor.Sensor sensor = getResource(
+                com.viam.sdk.core.component.sensor.Sensor.named(request.getName())
+        );
+      final Struct result = sensor.doCommand(request.getCommand().getFieldsMap());
+      responseObserver.onNext(Common.DoCommandResponse.newBuilder().setResult(result).build());
+      responseObserver.onCompleted();
+    }
+
+    @Override
     public void getReadings(GetReadingsRequest request,
                            StreamObserver<GetReadingsResponse> responseObserver) {
         final com.viam.sdk.core.component.sensor.Sensor sensor = getResource(


### PR DESCRIPTION
Adds `doCommand` implementation to the sensor service, where it was previously missing.

note to reviewers: I should emphasize that I have no experience writing java and copied the implementation, don't have tooling installed for java currently, and find navigating this repo to be pretty confusing (so many layers of directories!). So although the PR is short, it's probably worth eyeing over somewhat closely. I also didn't find anywhere obvious to add tests and opted not to create entirely new testing here, but if there's an appropriate place/model for adding testing here please let me know!