### PR TITLE
RSDK-8096 fix module-in-process with tarball

### DIFF
--- a/android/module-plugin/src/main/resources/mod-in-process.sh
+++ b/android/module-plugin/src/main/resources/mod-in-process.sh
@@ -34,7 +34,7 @@ trap removeTempFile EXIT
 intentURI="intent:#Intent;action=com.viam.rdk.fgservice.START_MODULE"
 intentURI="$intentURI;S.secret=$_VIAM_FG_SECRET"
 intentURI="$intentURI;S.proc_file=$proc_file"
-intentURI="$intentURI;S.java_class_path=$JAR_PATH"
+intentURI="$intentURI;S.java_class_path=$(realpath $JAR_PATH)"
 intentURI="$intentURI;S.java_library_path=$LIBRARY_PATH"
 intentURI="$intentURI;S.java_entry_point_class=__MAIN_ENTRY_CLASS__"
 saveIFS="$IFS"


### PR DESCRIPTION
## What changed
- make JAR_PATH an abs path in the module-in-process intent
## Why
Startup hangs without this.
## Testing
For now, manual tests:
### Before
logcat would show:
```log
W  ClassLoader referenced unknown path: ./module.jar
E  error running thread for com.viam.sdk.android.examples.module.MyModuleInProcess
  java.lang.ClassNotFoundException: com.viam.sdk.android.module.fake.FakeContext
    at java.lang.Class.classForName(Native Method)
    at java.lang.Class.forName(Class.java:454)
    at com.viam.rdk.fgservice.ModuleStartReceiver$ModuleThread.run(RDKLaunch.kt:168)
  Caused by: java.lang.ClassNotFoundException: Didn't find class "com.viam.sdk.android.module.fake.FakeContext" on path: DexPathList[[],nativeLibraryDirectories=[./module.jar!/lib/x86_64, ./module.jar!/lib/x86, /system/lib64, /system/product/lib64, /system/lib64, /system/product/lib64]]
...
    at com.viam.rdk.fgservice.ModuleStartReceiver$ModuleThread.run(RDKLaunch.kt:168)
```
and RDK logs showed `Waiting for module to complete startup and registration` forever:
```log
7/2/2024, 5:34:10 PM warn robot_server.modmanager utils/ticker.go:22 Waiting for module to complete startup and registration module local-module-1
7/2/2024, 5:34:02 PM warn robot_server.modmanager utils/ticker.go:22 Waiting for module to complete startup and registration module local-module-1
7/2/2024, 5:34:00 PM info robot_server.modmanager.process.local-module-1_/data/user/0/com.viam.rdk.fgservice/cache/.viam/packages-local/data/module/synthetic-local-module-1-0_0_0/mod.sh.StdOut pexec/managed_process.go:282 \_ Broadcast completed: result=0 
```
### After
`Module successfully added`
```log
7/2/2024, 5:39:00 PM info robot_server.modmanager modmanager/manager.go:342 Module successfully added module local-module-1
7/2/2024, 5:39:00 PM info robot_server.modmanager modmanager/manager.go:1160 Registering component API and model from module module local-module-1 API rdk:component:generic model viam:generic:mygeneric
7/2/2024, 5:38:57 PM info robot_server.modmanager modmanager/manager.go:998 Waiting for module to respond to ready request module local-module-1
7/2/2024, 5:38:57 PM warn robot_server.modmanager utils/ticker.go:22 Waiting for module to complete startup and registration module local-module-1
7/2/2024, 5:38:56 PM info robot_server.modmanager.process.local-module-1_/data/user/0/com.viam.rdk.fgservice/cache/.viam/packages-local/data/module/synthetic-local-module-1-0_0_0/mod.sh.StdOut pexec/managed_process.go:282 \_ Broadcast completed: result=0 
```