### PR TITLE
RSDK-8061 meta-in-tarball for local android development

### DIFF
--- a/android/examples/module/README.md
+++ b/android/examples/module/README.md
@@ -15,19 +15,21 @@ For **local development**, i.e. testing your module without uploading to the reg
 ./gradlew pushModuleAdbDebug
 ```
 
+(Or run the `pushModuleAdbDebug` gradle task from the 'other' section of gradle tasks in Android Studio).
+
 This will push files to the active device or emulator in adb. Then add this to the modules array in your json config:
 
 ```json
 {
     "name": "android-module",
-    "executable_path": "/sdcard/Download/FOLDER_NAME/module.tar.gz",
+    "executable_path": "/sdcard/Download/FOLDER_NAME.tar.gz",
     "type": "local"
 }
 ```
 
-Then add a local generic component from the builder with model `viam:generic:mygeneric`.
-
 `FOLDER_NAME` is the root folder of your module, for example `SimpleAndroidModule` or `SimpleAndroidModuleKT` if you're starting from the examples.
+
+Finally, add a local generic component from the builder with model `viam:generic:mygeneric`.
 
 For **registry upload**, run:
 

--- a/android/module-plugin/src/main/groovy/com/viam/sdk/android/module/android-module-plugin.groovy
+++ b/android/module-plugin/src/main/groovy/com/viam/sdk/android/module/android-module-plugin.groovy
@@ -93,20 +93,21 @@ class AndroidModulePlugin implements Plugin<Project> {
                 }
 
                 def copyMetaTask = project.task("copyMeta${variant.name.capitalize()}") {
+                    dependsOn assembleTask
                     doLast {
                         new File(outputDir, "meta.json").text = getClass().getResourceAsStream("/meta.json").getText()
                     }
                 }
 
                 def tarModuleTask = project.task("tarModule${variant.name.capitalize()}", type: Exec) {
-                    dependsOn assembleTask
-                    commandLine "tar", "czf", "${outputDir}/module.tar.gz", "-C", outputDir, "mod.sh", "module.jar"
+                    dependsOn copyMetaTask
+                    commandLine "tar", "czf", "${outputDir}/module.tar.gz", "-C", outputDir, "meta.json", "mod.sh", "module.jar"
                 }
 
                 project.task("pushModuleAdb${variant.name.capitalize()}", type: Exec) {
-                    dependsOn(copyMetaTask, tarModuleTask)
+                    dependsOn tarModuleTask
                     def destDir = "/sdcard/Download/${project.rootProject.projectDir.name}"
-                    commandLine "bash", "-c", "adb shell mkdir -p ${destDir} && adb push ${outputDir}/module.tar.gz ${outputDir}/meta.json ${destDir}"
+                    commandLine "bash", "-c", "adb shell mkdir -p ${destDir} && adb push ${outputDir}/module.tar.gz ${destDir}"
                 }
             }
         }

--- a/android/module-plugin/src/main/groovy/com/viam/sdk/android/module/android-module-plugin.groovy
+++ b/android/module-plugin/src/main/groovy/com/viam/sdk/android/module/android-module-plugin.groovy
@@ -106,8 +106,7 @@ class AndroidModulePlugin implements Plugin<Project> {
 
                 project.task("pushModuleAdb${variant.name.capitalize()}", type: Exec) {
                     dependsOn tarModuleTask
-                    def destDir = "/sdcard/Download/${project.rootProject.projectDir.name}"
-                    commandLine "bash", "-c", "adb shell mkdir -p ${destDir} && adb push ${outputDir}/module.tar.gz ${destDir}"
+                    commandLine "adb", "push", "${outputDir}/module.tar.gz", "/sdcard/Download/${project.rootProject.projectDir.name}.tar.gz"
                 }
             }
         }


### PR DESCRIPTION
## What changed
- use meta-in-tarball for local android development (new pattern) instead of side-by-side meta.json (old pattern)
- update docs
## Why
Meta-in-tarball is cleaner (single file to deal with) and we want to deprecate side-by-side eventually.
## Testing
Tarball has meta.json as expected:
```sh
$ tar tf module/build/outputs/module/debug/module.tar.gz 
meta.json
mod.sh
module.jar
```
File gets copied correctly:
```sh
$ ./gradlew pushModuleAdbDebug

> Task :module:stripDebugDebugSymbols
Unable to strip the following libraries, packaging them as they are: libjingle_peerconnection_so.so.

> Task :module:pushModuleAdbDebug
/PATH/viam-java-sdk/standalone-examples/SimpleAndroidModule/module/build/outputs/module/debug/module.tar.gz: 1 file pushed. 275.0 MB/s (23993693 bytes in 0.083s)

BUILD SUCCESSFUL in 51s
36 actionable tasks: 36 executed
```

And with tar path configured:

![Screenshot 2024-07-10 at 18-58-15 apk1 - Viam](https://github.com/viamrobotics/viam-java-sdk/assets/7256523/417ce4f4-82f4-4d16-b439-209a14249575)

Module starts successfully:

![Screenshot 2024-07-10 at 19-00-19 apk1 - Viam](https://github.com/viamrobotics/viam-java-sdk/assets/7256523/8b58a6de-6934-43b5-b37d-78e11f3b1d94)