### PR TITLE
RSDK-9902 - use same action as other SDKs for opening proto PRs

### DIFF
--- a/.github/workflows/update-protos.yml
+++ b/.github/workflows/update-protos.yml
@@ -29,16 +29,17 @@ jobs:
         run: make buf
 
       - name: Add + Commit + Open PR
-        shell: bash
-        run: |
-          git checkout -b workflow/update-protos || git checkout workflow/update-protos
-          git add --all
-          git -c author.name=viambot -c author.email=viambot@users.noreply.github.com -c committer.name=GitHub -c committer.email=noreply@github.com commit -m "[WORKFLOW] Updating protos from ${{ github.event.client_payload.repo_name }}, commit: ${{ github.event.client_payload.sha }}"
-          git -c pull.ff=only pull origin workflow/update-protos || true  # do not fail if the branch doesn't exist
-          git push -f origin workflow/update-protos
-          gh pr view workflow/update-protos && gh pr reopen workflow/update-protos || gh pr create -B main -H workflow/update-protos -t "Automated Protos Update" -b "This is an auto-generated PR to update proto definitions. Check the commits to see which repos and commits are responsible for the changes" -a njooma -r njooma
-        env:
-          GH_TOKEN: ${{ secrets.GIT_ACCESS_TOKEN }}
+        uses: peter-evans/create-pull-request@v7
+        with:
+          commit-message: '[WORKFLOW] Updating protos from ${{ github.event.client_payload.repo_name }}, commit: ${{ github.event.client_payload.sha }}'
+          branch: 'workflow/update-proto'
+          delete-branch: true
+          base: main
+          title: Automated Protos Update
+          body: This is an auto-generated PR to update proto definitions. Check the commits to see which repos and commits are responsible for the changes
+          assignees: njooma
+          reviewers: njooma
+          token: ${{ secrets.GIT_ACCESS_TOKEN }}
 
       - name: Notify slack of failure
         uses: slackapi/slack-github-action@v1.24.0


### PR DESCRIPTION
This was the only SDK to manually create PRs as opposed to using the peter evans action. It's also the only SDK to have the update protos job fail just now because of failures with the `open PR` step. Coincidence??? Honestly, maybe. Unclear. But it's very possible that it's related, and getting this to use the same action as the other SDKs has been on the backlog for a while so might as well get it done.

If this is insufficient to fix the update protos job, then I'll dig into that when we see the job fail again.